### PR TITLE
Refactor AppScanIssue field types to Object and update usage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.hcl.appscan</groupId>
 	<artifactId>appscan-issue-gateway</artifactId>
-	<version>1.2.1</version>
+	<version>1.2.2</version>
 	<packaging>jar</packaging>
 	<name>appscan-issue-gateway</name>
 	<description>AppScan Issue Gateway Service</description>

--- a/providers/common/IAppScanIssue.groovy
+++ b/providers/common/IAppScanIssue.groovy
@@ -1,6 +1,6 @@
 /**
  * � Copyright IBM Corporation 2018.
- * � Copyright HCL Technologies Ltd. 2018.
+ * � Copyright HCL Technologies Ltd. 2018,2026.
  * LICENSE: Apache License, Version 2.0 https://www.apache.org/licenses/LICENSE-2.0
  */
 package common

--- a/providers/common/IAppScanIssue.groovy
+++ b/providers/common/IAppScanIssue.groovy
@@ -18,7 +18,7 @@ interface IAppScanIssue {
 
 	File getIssueDetails()
 
-	String get(String name)
+	Object get(String name)
 
 }
 

--- a/src/main/java/com/hcl/appscan/issuegateway/appscanprovider/FilterHandler.java
+++ b/src/main/java/com/hcl/appscan/issuegateway/appscanprovider/FilterHandler.java
@@ -1,5 +1,5 @@
 /**
- * © Copyright HCL Technologies Ltd. 2019,2026.
+ * © Copyright HCL Technologies Ltd. 2019, 2026.
  * LICENSE: Apache License, Version 2.0 https://www.apache.org/licenses/LICENSE-2.0
  */
 package com.hcl.appscan.issuegateway.appscanprovider;

--- a/src/main/java/com/hcl/appscan/issuegateway/appscanprovider/FilterHandler.java
+++ b/src/main/java/com/hcl/appscan/issuegateway/appscanprovider/FilterHandler.java
@@ -94,7 +94,7 @@ public abstract class FilterHandler {
 	private boolean containsMatch(AppScanIssue issue, Map<String, List<Pattern>> patterns) {
 		for (String field : patterns.keySet()) {
 			for (Pattern p : patterns.get(field)) {
-				Matcher m = p.matcher(issue.get(field));
+				Matcher m = p.matcher((String)issue.get(field));
 				if (m.matches()) {
 					return true;
 				}

--- a/src/main/java/com/hcl/appscan/issuegateway/appscanprovider/FilterHandler.java
+++ b/src/main/java/com/hcl/appscan/issuegateway/appscanprovider/FilterHandler.java
@@ -1,5 +1,5 @@
 /**
- * © Copyright HCL Technologies Ltd. 2019.
+ * © Copyright HCL Technologies Ltd. 2019,2026.
  * LICENSE: Apache License, Version 2.0 https://www.apache.org/licenses/LICENSE-2.0
  */
 package com.hcl.appscan.issuegateway.appscanprovider;

--- a/src/main/java/com/hcl/appscan/issuegateway/appscanprovider/ase/ASECreateIssueAndSyncHandler.java
+++ b/src/main/java/com/hcl/appscan/issuegateway/appscanprovider/ase/ASECreateIssueAndSyncHandler.java
@@ -1,5 +1,5 @@
 /**
- * © Copyright HCL Technologies Ltd. 2019,2026.
+ * © Copyright HCL Technologies Ltd. 2019, 2026.
  * LICENSE: Apache License, Version 2.0 https://www.apache.org/licenses/LICENSE-2.0
  */
 package com.hcl.appscan.issuegateway.appscanprovider.ase;

--- a/src/main/java/com/hcl/appscan/issuegateway/appscanprovider/ase/ASECreateIssueAndSyncHandler.java
+++ b/src/main/java/com/hcl/appscan/issuegateway/appscanprovider/ase/ASECreateIssueAndSyncHandler.java
@@ -44,10 +44,10 @@ public class ASECreateIssueAndSyncHandler {
 					rtcProviderClass.getDeclaredMethod( "setupConnection", new Class[] {} ).invoke( rtcInstance, new Object[] {} ) ;
 				}
 				
-				((AppScanIssue)issue).set("Issue Type", HtmlUtils.htmlUnescape(((AppScanIssue)issue).get("Issue Type")).replaceAll("\"", "'"));
-				((AppScanIssue)issue).set("Location", HtmlUtils.htmlUnescape(((AppScanIssue)issue).get("Location")).replaceAll("\"", "'"));
-				provider.submitIssue(issue, jobData.getImData().getConfig(), errors, results);
-				externalIdHandler.updateExternalId(issue.get("id"), jobData, errors, results);
+			((AppScanIssue)issue).set("Issue Type", HtmlUtils.htmlUnescape((String)((AppScanIssue)issue).get("Issue Type")).replaceAll("\"", "'"));
+			((AppScanIssue)issue).set("Location", HtmlUtils.htmlUnescape((String)((AppScanIssue)issue).get("Location")).replaceAll("\"", "'"));
+			provider.submitIssue(issue, jobData.getImData().getConfig(), errors, results);
+			externalIdHandler.updateExternalId((String)issue.get("id"), jobData, errors, results);
 			}
 		}
 	}

--- a/src/main/java/com/hcl/appscan/issuegateway/appscanprovider/ase/ASECreateIssueAndSyncHandler.java
+++ b/src/main/java/com/hcl/appscan/issuegateway/appscanprovider/ase/ASECreateIssueAndSyncHandler.java
@@ -1,5 +1,5 @@
 /**
- * © Copyright HCL Technologies Ltd. 2019. 
+ * © Copyright HCL Technologies Ltd. 2019,2026.
  * LICENSE: Apache License, Version 2.0 https://www.apache.org/licenses/LICENSE-2.0
  */
 package com.hcl.appscan.issuegateway.appscanprovider.ase;

--- a/src/main/java/com/hcl/appscan/issuegateway/appscanprovider/ase/ASEExternalIdHandler.java
+++ b/src/main/java/com/hcl/appscan/issuegateway/appscanprovider/ase/ASEExternalIdHandler.java
@@ -1,5 +1,5 @@
 /**
- * © Copyright HCL Technologies Ltd. 2019,2026.
+ * © Copyright HCL Technologies Ltd. 2019, 2026.
  * LICENSE: Apache License, Version 2.0 https://www.apache.org/licenses/LICENSE-2.0
  */
 package com.hcl.appscan.issuegateway.appscanprovider.ase;

--- a/src/main/java/com/hcl/appscan/issuegateway/appscanprovider/ase/ASEExternalIdHandler.java
+++ b/src/main/java/com/hcl/appscan/issuegateway/appscanprovider/ase/ASEExternalIdHandler.java
@@ -1,5 +1,5 @@
 /**
- * © Copyright HCL Technologies Ltd. 2019. 
+ * © Copyright HCL Technologies Ltd. 2019,2026.
  * LICENSE: Apache License, Version 2.0 https://www.apache.org/licenses/LICENSE-2.0
  */
 package com.hcl.appscan.issuegateway.appscanprovider.ase;

--- a/src/main/java/com/hcl/appscan/issuegateway/appscanprovider/ase/ASEExternalIdHandler.java
+++ b/src/main/java/com/hcl/appscan/issuegateway/appscanprovider/ase/ASEExternalIdHandler.java
@@ -22,7 +22,7 @@ import com.hcl.appscan.issuegateway.issues.PushJobData;
 public class ASEExternalIdHandler implements ASEConstants {
 
 	public boolean isExternalIdPresent(AppScanIssue issue, PushJobData jobData, List<String> errors)throws Exception {
-		ResponseEntity<ASEIssueDetail> details= getIssueDetail(issue.get("id"), jobData, errors);
+		ResponseEntity<ASEIssueDetail> details= getIssueDetail((String)issue.get("id"), jobData, errors);
 		ASEIssueDetail.AttributeCollection.Attributes [] attributesArray=details.getBody().getAttributeCollection().getAttributeArray();
 		// this is to directly check the externalId which is present as the 40th element in the attribute array
 		if (attributesArray[39].getLookup().equals("externalid")) {

--- a/src/main/java/com/hcl/appscan/issuegateway/appscanprovider/ase/ASEIssueReportHandler.java
+++ b/src/main/java/com/hcl/appscan/issuegateway/appscanprovider/ase/ASEIssueReportHandler.java
@@ -1,5 +1,5 @@
 /**
- * © Copyright HCL Technologies Ltd. 2019,2026.
+ * © Copyright HCL Technologies Ltd. 2019, 2026.
  * LICENSE: Apache License, Version 2.0 https://www.apache.org/licenses/LICENSE-2.0
  */
 package com.hcl.appscan.issuegateway.appscanprovider.ase;

--- a/src/main/java/com/hcl/appscan/issuegateway/appscanprovider/ase/ASEIssueReportHandler.java
+++ b/src/main/java/com/hcl/appscan/issuegateway/appscanprovider/ase/ASEIssueReportHandler.java
@@ -1,5 +1,5 @@
 /**
- * © Copyright HCL Technologies Ltd. 2019. 
+ * © Copyright HCL Technologies Ltd. 2019,2026.
  * LICENSE: Apache License, Version 2.0 https://www.apache.org/licenses/LICENSE-2.0
  */
 package com.hcl.appscan.issuegateway.appscanprovider.ase;

--- a/src/main/java/com/hcl/appscan/issuegateway/appscanprovider/ase/ASEIssueReportHandler.java
+++ b/src/main/java/com/hcl/appscan/issuegateway/appscanprovider/ase/ASEIssueReportHandler.java
@@ -37,9 +37,9 @@ public class ASEIssueReportHandler {
 	
 	public void retrieveReports(AppScanIssue[] issues, PushJobData jobData, List<String> errors) {
 	
-		for (AppScanIssue issue : issues) {
-		    try {
-			    File reportFile = getFile(jobData, issue.get("id"), errors);
+	for (AppScanIssue issue : issues) {
+	    try {
+		    File reportFile = getFile(jobData, (String)issue.get("id"), errors);
 		    	if (reportFile != null) {
 		    		issue.setIssueDetails(reportFile);
 		    	}

--- a/src/main/java/com/hcl/appscan/issuegateway/appscanprovider/asoc/ASOCCommentHandler.java
+++ b/src/main/java/com/hcl/appscan/issuegateway/appscanprovider/asoc/ASOCCommentHandler.java
@@ -26,7 +26,7 @@ public class ASOCCommentHandler {
 	private static final String COMMENT_TOKEN = "AppScan Issue Gateway";
 
 	public String[] getComments(AppScanIssue issue, PushJobData jobData, List<String> errors) {
-		String url = jobData.getAppscanData().getUrl() + REST_COMMENT.replace("ISSUEID", issue.get("Id"));
+		String url = jobData.getAppscanData().getUrl() + REST_COMMENT.replace("ISSUEID", (String)issue.get("Id"));
 
 		RestTemplate restTemplate;
 		if(jobData.getAppscanData().getTrusted().equalsIgnoreCase("false")){

--- a/src/main/java/com/hcl/appscan/issuegateway/appscanprovider/asoc/ASOCCommentHandler.java
+++ b/src/main/java/com/hcl/appscan/issuegateway/appscanprovider/asoc/ASOCCommentHandler.java
@@ -1,6 +1,6 @@
 /**
  * © Copyright IBM Corporation 2018.
- * © Copyright HCL Technologies Ltd. 2018,2024.
+ * © Copyright HCL Technologies Ltd. 2018,2026.
  * LICENSE: Apache License, Version 2.0 https://www.apache.org/licenses/LICENSE-2.0
  */
 package com.hcl.appscan.issuegateway.appscanprovider.asoc;

--- a/src/main/java/com/hcl/appscan/issuegateway/appscanprovider/asoc/ASOCCommentHandler.java
+++ b/src/main/java/com/hcl/appscan/issuegateway/appscanprovider/asoc/ASOCCommentHandler.java
@@ -1,6 +1,6 @@
 /**
  * © Copyright IBM Corporation 2018.
- * © Copyright HCL Technologies Ltd. 2018,2026.
+ * © Copyright HCL Technologies Ltd. 2018, 2026.
  * LICENSE: Apache License, Version 2.0 https://www.apache.org/licenses/LICENSE-2.0
  */
 package com.hcl.appscan.issuegateway.appscanprovider.asoc;

--- a/src/main/java/com/hcl/appscan/issuegateway/appscanprovider/asoc/ASOCReportHandler.java
+++ b/src/main/java/com/hcl/appscan/issuegateway/appscanprovider/asoc/ASOCReportHandler.java
@@ -36,8 +36,8 @@ public class ASOCReportHandler {
 		for (AppScanIssue issue : issues) {
 			try {
 				String url = jobData.getAppscanData().getUrl()
-						+REST_ISSUE_DETAIL.replace("ISSUEID",issue.get("Id"));
-				
+						+REST_ISSUE_DETAIL.replace("ISSUEID",(String)issue.get("Id"));
+
 				List<HttpMessageConverter<?>> messageConverters = new ArrayList<>();
 				messageConverters.add(new ByteArrayHttpMessageConverter());
 				RestTemplate restTemplate;

--- a/src/main/java/com/hcl/appscan/issuegateway/appscanprovider/asoc/ASOCReportHandler.java
+++ b/src/main/java/com/hcl/appscan/issuegateway/appscanprovider/asoc/ASOCReportHandler.java
@@ -1,6 +1,6 @@
 /**
  * © Copyright IBM Corporation 2018.
- * © Copyright HCL Technologies Ltd. 2018, 2024.
+ * © Copyright HCL Technologies Ltd. 2018, 2026.
  * LICENSE: Apache License, Version 2.0 https://www.apache.org/licenses/LICENSE-2.0
  */
 package com.hcl.appscan.issuegateway.appscanprovider.asoc;

--- a/src/main/java/com/hcl/appscan/issuegateway/issues/AppScanIssue.java
+++ b/src/main/java/com/hcl/appscan/issuegateway/issues/AppScanIssue.java
@@ -17,16 +17,16 @@ import common.IAppScanIssue;
 public class AppScanIssue implements IAppScanIssue {
 
 	private File issueDetails;
-	private Map<String, String> issueFields = new HashMap<>();
+	private Map<String, Object> issueFields = new HashMap<>();
 
 	@Override
 	@JsonAnyGetter
-	public String get(String name) {
+	public Object get(String name) {
 		return issueFields.get(name);
 	}
 
 	@JsonAnySetter
-	public void set(String name, String value) {
+	public void set(String name, Object value) {
 		issueFields.put(name, value);
 	}
 

--- a/src/main/java/com/hcl/appscan/issuegateway/issues/AppScanIssue.java
+++ b/src/main/java/com/hcl/appscan/issuegateway/issues/AppScanIssue.java
@@ -1,6 +1,6 @@
 /**
  * © Copyright IBM Corporation 2018.
- * © Copyright HCL Technologies Ltd. 2018.
+ * © Copyright HCL Technologies Ltd. 2018,2026.
  * LICENSE: Apache License, Version 2.0 https://www.apache.org/licenses/LICENSE-2.0
  */
 package com.hcl.appscan.issuegateway.issues;

--- a/src/main/java/com/hcl/appscan/issuegateway/issues/AppScanIssue.java
+++ b/src/main/java/com/hcl/appscan/issuegateway/issues/AppScanIssue.java
@@ -1,6 +1,6 @@
 /**
  * © Copyright IBM Corporation 2018.
- * © Copyright HCL Technologies Ltd. 2018,2026.
+ * © Copyright HCL Technologies Ltd. 2018, 2026.
  * LICENSE: Apache License, Version 2.0 https://www.apache.org/licenses/LICENSE-2.0
  */
 package com.hcl.appscan.issuegateway.issues;

--- a/src/main/java/common/IAppScanIssue.java
+++ b/src/main/java/common/IAppScanIssue.java
@@ -1,6 +1,6 @@
 /**
  * � Copyright IBM Corporation 2018.
- * � Copyright HCL Technologies Ltd. 2018.
+ * � Copyright HCL Technologies Ltd. 2018,2026.
  * LICENSE: Apache License, Version 2.0 https://www.apache.org/licenses/LICENSE-2.0
  */
 package common;

--- a/src/main/java/common/IAppScanIssue.java
+++ b/src/main/java/common/IAppScanIssue.java
@@ -11,7 +11,7 @@ public interface IAppScanIssue {
 
 	File getIssueDetails();
 
-	String get(String name);
+	Object get(String name);
 
 }
 

--- a/src/main/java/common/IAppScanIssue.java
+++ b/src/main/java/common/IAppScanIssue.java
@@ -1,6 +1,6 @@
 /**
  * � Copyright IBM Corporation 2018.
- * � Copyright HCL Technologies Ltd. 2018,2026.
+ * � Copyright HCL Technologies Ltd. 2018, 2026.
  * LICENSE: Apache License, Version 2.0 https://www.apache.org/licenses/LICENSE-2.0
  */
 package common;


### PR DESCRIPTION
Changed issue field storage from String to Object in AppScanIssue and related interfaces to allow for more flexible value types due to introduction of CustomFields field in api - GET /api/v4/Issues/{scope}/{scopeId}. Updated all usages and casts accordingly throughout the codebase.